### PR TITLE
Normalized Transformer + REPA

### DIFF
--- a/dit/configs.py
+++ b/dit/configs.py
@@ -3,17 +3,28 @@ from typing import Optional, Dict
 
 @dataclass
 class ModelConfig:
+    # Transformer
     n_layers : int = 12
     n_heads : int = 12
     d_model : int = 768
+    flash : bool = True
+
+    # input/latent
     image_size : int = 512
     sample_size : int = 64
     channels : int = 4
     patch_size : int = 4
     use_vae = True
-    flash : bool = True
+    
+    # Guidance
     take_label : bool = True # Take the batch as (pixel_values, label_str) instead of pixel_values
     cfg_prob : float = 0.1
+
+    # REPA
+    repa_weight : float = 1.0
+    repa_batch_size : int = 32
+    repa_layer_ind : int = 4
+    repa_pool_factor : int = 1 # If 256 patches, matching dinov2small, set to 1, if doing 1024, set to 2
 
 @dataclass
 class TrainConfig:
@@ -24,7 +35,7 @@ class TrainConfig:
     # optimizer
     opt : str = "AdamW"
     opt_kwargs : Dict = field(default_factory = lambda : {
-        "lr": 1.0e-3,
+        "lr": 1.0e-2,
         "eps": 1.0e-15,
         "betas" : (0.9, 0.96),
         "weight_decay" : 0.00,
@@ -32,27 +43,38 @@ class TrainConfig:
     })
 
     # scheduler
-    scheduler: Optional[str] = None#"CosineDecayAfterWarmup"
+    scheduler: Optional[str] = "CosineDecay"
     scheduler_kwargs: Dict = field(default_factory=lambda: {
-        "warmup_steps": 400,  # Linear warmup over 1000 steps
         "T_max" : 1000000,
-        "eta_min" : 1.0e-6
+        "eta_min" : 5.0e-6
     })
 
+    # Saving
     checkpoint_root_dir = "checkpoints"
 
     log_interval : int = 1
     sample_interval : int = 50
     save_interval : int = 2500
-    resume : bool = True
+    val_interval : int = 1
+    resume : bool = False
 
+    # Sampling
     n_samples : int = 4 # Number of samples to log each time (too many gets crowded)
     sample_prompts = ["a dog in a park", "the blue sky", "the ocean", "the beach"]
+    
+    # Validating
+    val_batch_mult = 4
+
     grad_clip : float = -1 # Clip grad norms to this value
     normalize_every : int = 1
     
 @dataclass
 class LoggingConfig:
-    run_name : str = "coco 150M (adam, +ngpt, lr=1e-3)"
+    run_name : str = "coco 150M (adam, +ngpt, lr=1e-2)"
     wandb_entity : str = "shahbuland"
     wandb_project : str = "mnist_sanity"
+
+@dataclass
+class SamplerConfig:
+    n_steps : int = 100
+    cfg_scale : float = 1.5

--- a/dit/configs.py
+++ b/dit/configs.py
@@ -3,7 +3,7 @@ from typing import Optional, Dict
 
 @dataclass
 class ModelConfig:
-    n_layers : int = 4
+    n_layers : int = 12
     n_heads : int = 6
     d_model : int = 384
     image_size : int = 64
@@ -26,7 +26,8 @@ class TrainConfig:
     opt_kwargs : Dict = field(default_factory = lambda : {
         "lr": 1.0e-4,
         "eps": 1e-7,
-        "betas" : (0.9, 0.96)
+        "betas" : (0.9, 0.96),
+        "weight_decay" : 0.0
     })
 
     # scheduler
@@ -42,10 +43,11 @@ class TrainConfig:
     n_samples : int = 4 # Number of samples to log each time (too many gets crowded)
     sample_prompts = [f"A drawing of the digit {i}" for i in ["one", "two", "three", "four"]]
     grad_clip : float = -1 # Clip grad norms to this value
+    normalize_every : int = 10
     
 
 @dataclass
 class LoggingConfig:
-    run_name : str = "mnist tiny (+cfg)"
+    run_name : str = "mnist 40M (+ngpt+more norms!)"
     wandb_entity : str = "shahbuland"
     wandb_project : str = "mnist_sanity"

--- a/dit/configs.py
+++ b/dit/configs.py
@@ -18,6 +18,7 @@ class ModelConfig:
     
     # Guidance
     take_label : bool = True # Take the batch as (pixel_values, label_str) instead of pixel_values
+    text_d_model : int = 512 # Hidden size of text embedding model
     cfg_prob : float = 0.1
 
     # REPA
@@ -55,7 +56,7 @@ class TrainConfig:
     log_interval : int = 1
     sample_interval : int = 50
     save_interval : int = 2500
-    val_interval : int = 1
+    val_interval : int = 1000
     resume : bool = False
 
     # Sampling
@@ -70,7 +71,7 @@ class TrainConfig:
     
 @dataclass
 class LoggingConfig:
-    run_name : str = "coco 150M (adam, +ngpt, lr=1e-2)"
+    run_name : str = "coco 150M (repa, lr=1e-2)"
     wandb_entity : str = "shahbuland"
     wandb_project : str = "mnist_sanity"
 

--- a/dit/configs.py
+++ b/dit/configs.py
@@ -4,30 +4,31 @@ from typing import Optional, Dict
 @dataclass
 class ModelConfig:
     n_layers : int = 12
-    n_heads : int = 6
-    d_model : int = 384
-    image_size : int = 64
+    n_heads : int = 12
+    d_model : int = 768
+    image_size : int = 512
     sample_size : int = 64
-    channels : int = 3
+    channels : int = 4
     patch_size : int = 4
-    use_vae = False
-    flash : bool = False
+    use_vae = True
+    flash : bool = True
     take_label : bool = True # Take the batch as (pixel_values, label_str) instead of pixel_values
     cfg_prob : float = 0.1
 
 @dataclass
 class TrainConfig:
-    dataset : str = "mnist"
-    target_batch_size : int = 64
-    batch_size : int = 16
+    dataset : str = "coco"
+    target_batch_size : int = 256
+    batch_size : int = 128
     epochs : int = 100
     # optimizer
     opt : str = "AdamW"
     opt_kwargs : Dict = field(default_factory = lambda : {
         "lr": 1.0e-3,
-        "eps": 1e-7,
+        "eps": 1.0e-15,
         "betas" : (0.9, 0.96),
-        "weight_decay" : 0.0
+        "weight_decay" : 0.00,
+        #"precondition_frequency" : 50
     })
 
     # scheduler
@@ -38,25 +39,20 @@ class TrainConfig:
         "eta_min" : 1.0e-6
     })
 
+    checkpoint_root_dir = "checkpoints"
+
     log_interval : int = 1
     sample_interval : int = 50
-    n_samples : int = 8 # Number of samples to log each time (too many gets crowded)
-    sample_prompts = [
-        "one",
-        "two",
-        "three",
-        "four",
-        "five",
-        "six",
-        "seven",
-        "eight"
-    ]
+    save_interval : int = 2500
+    resume : bool = True
+
+    n_samples : int = 4 # Number of samples to log each time (too many gets crowded)
+    sample_prompts = ["a dog in a park", "the blue sky", "the ocean", "the beach"]
     grad_clip : float = -1 # Clip grad norms to this value
     normalize_every : int = 1
     
-
 @dataclass
 class LoggingConfig:
-    run_name : str = "mnist 40M (+ngpt +1e-3 lr)"
+    run_name : str = "coco 150M (adam, +ngpt, lr=1e-3)"
     wandb_entity : str = "shahbuland"
     wandb_project : str = "mnist_sanity"

--- a/dit/configs.py
+++ b/dit/configs.py
@@ -31,12 +31,12 @@ class ModelConfig:
 class TrainConfig:
     dataset : str = "coco"
     target_batch_size : int = 256
-    batch_size : int = 128
+    batch_size : int = 64
     epochs : int = 100
     # optimizer
     opt : str = "AdamW"
     opt_kwargs : Dict = field(default_factory = lambda : {
-        "lr": 1.0e-2,
+        "lr": 1.0e-3,
         "eps": 1.0e-15,
         "betas" : (0.9, 0.96),
         "weight_decay" : 0.00,
@@ -44,7 +44,7 @@ class TrainConfig:
     })
 
     # scheduler
-    scheduler: Optional[str] = "CosineDecay"
+    scheduler: Optional[str] = None#"CosineDecay"
     scheduler_kwargs: Dict = field(default_factory=lambda: {
         "T_max" : 1000000,
         "eta_min" : 5.0e-6
@@ -54,14 +54,23 @@ class TrainConfig:
     checkpoint_root_dir = "checkpoints"
 
     log_interval : int = 1
-    sample_interval : int = 50
+    sample_interval : int = 100
     save_interval : int = 2500
     val_interval : int = 1000
     resume : bool = False
 
     # Sampling
-    n_samples : int = 4 # Number of samples to log each time (too many gets crowded)
-    sample_prompts = ["a dog in a park", "the blue sky", "the ocean", "the beach"]
+    n_samples : int = 8 # Number of samples to log each time (too many gets crowded)
+    sample_prompts = [
+        "a dog in a park",
+        "the blue sky",
+        "the ocean",
+        "the beach",
+        "a beautiful rainbow feathered bird",
+        "a snowy mountain with clear skies",
+        "a woman cutting a cake",
+        "a red sports car"
+    ]
     
     # Validating
     val_batch_mult = 4
@@ -71,7 +80,7 @@ class TrainConfig:
     
 @dataclass
 class LoggingConfig:
-    run_name : str = "coco 150M (repa, lr=1e-2)"
+    run_name : str = "coco 150M (ngpt, lr=1e-3 + repa + norm_repa)"
     wandb_entity : str = "shahbuland"
     wandb_project : str = "mnist_sanity"
 

--- a/dit/configs.py
+++ b/dit/configs.py
@@ -13,12 +13,13 @@ class ModelConfig:
     use_vae = False
     flash : bool = False
     take_label : bool = True # Take the batch as (pixel_values, label_str) instead of pixel_values
+    cfg_prob : float = 0.1
 
 @dataclass
 class TrainConfig:
     dataset : str = "mnist"
     target_batch_size : int = 64
-    batch_size : int = 16
+    batch_size : int = 32
     epochs : int = 100
     # optimizer
     opt : str = "AdamW"
@@ -29,7 +30,7 @@ class TrainConfig:
     })
 
     # scheduler
-    scheduler: Optional[str] = "CosineDecayAfterWarmup"
+    scheduler: Optional[str] = None#"CosineDecayAfterWarmup"
     scheduler_kwargs: Dict = field(default_factory=lambda: {
         "warmup_steps": 400,  # Linear warmup over 1000 steps
         "T_max" : 1000000,
@@ -45,6 +46,6 @@ class TrainConfig:
 
 @dataclass
 class LoggingConfig:
-    run_name : str = "mnist tiny (+cond)"
+    run_name : str = "mnist tiny (+cfg)"
     wandb_entity : str = "shahbuland"
     wandb_project : str = "mnist_sanity"

--- a/dit/configs.py
+++ b/dit/configs.py
@@ -19,12 +19,12 @@ class ModelConfig:
 class TrainConfig:
     dataset : str = "mnist"
     target_batch_size : int = 64
-    batch_size : int = 32
+    batch_size : int = 16
     epochs : int = 100
     # optimizer
     opt : str = "AdamW"
     opt_kwargs : Dict = field(default_factory = lambda : {
-        "lr": 1.0e-4,
+        "lr": 1.0e-3,
         "eps": 1e-7,
         "betas" : (0.9, 0.96),
         "weight_decay" : 0.0
@@ -40,14 +40,23 @@ class TrainConfig:
 
     log_interval : int = 1
     sample_interval : int = 50
-    n_samples : int = 4 # Number of samples to log each time (too many gets crowded)
-    sample_prompts = [f"A drawing of the digit {i}" for i in ["one", "two", "three", "four"]]
+    n_samples : int = 8 # Number of samples to log each time (too many gets crowded)
+    sample_prompts = [
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+        "six",
+        "seven",
+        "eight"
+    ]
     grad_clip : float = -1 # Clip grad norms to this value
-    normalize_every : int = 10
+    normalize_every : int = 1
     
 
 @dataclass
 class LoggingConfig:
-    run_name : str = "mnist 40M (+ngpt+more norms!)"
+    run_name : str = "mnist 40M (+ngpt +1e-3 lr)"
     wandb_entity : str = "shahbuland"
     wandb_project : str = "mnist_sanity"

--- a/dit/data/__init__.py
+++ b/dit/data/__init__.py
@@ -5,14 +5,14 @@ from . import (
     imagenet
 )
 
-def create_loader(dataset_name, batch_size, image_size, deterministic=False):
+def create_loader(dataset_name, batch_size, image_size, deterministic=True, split='train'):
     if dataset_name.lower() == 'mnist':
         dataset = mnist.CustomMNISTDataset(image_size=image_size)
     elif dataset_name.lower() == 'imagenet':
         dataset = imagenet.CustomImageNetDataset(image_size=image_size)
     elif dataset_name.lower() == 'coco':
         from . import coco
-        dataset = coco.CustomCOCODataset(image_size=image_size)
+        dataset = coco.CustomCOCODataset(image_size=image_size, split = split)
     else:
         raise ValueError(f"Dataset '{dataset_name}' is not supported.")
 
@@ -23,7 +23,8 @@ def create_loader(dataset_name, batch_size, image_size, deterministic=False):
     return DataLoader(
         dataset,
         batch_size=batch_size,
-        shuffle=True,
+        shuffle=True if split == 'train' else False,
         generator=generator,
-        pin_memory = True
+        pin_memory = True,
+        num_workers = 4
     )

--- a/dit/data/__init__.py
+++ b/dit/data/__init__.py
@@ -2,7 +2,8 @@ from torch.utils.data import DataLoader
 import torch
 from . import (
     mnist,
-    imagenet
+    imagenet,
+    coco
 )
 
 def create_loader(dataset_name, batch_size, image_size, deterministic=True, split='train'):
@@ -11,7 +12,6 @@ def create_loader(dataset_name, batch_size, image_size, deterministic=True, spli
     elif dataset_name.lower() == 'imagenet':
         dataset = imagenet.CustomImageNetDataset(image_size=image_size)
     elif dataset_name.lower() == 'coco':
-        from . import coco
         dataset = coco.CustomCOCODataset(image_size=image_size, split = split)
     else:
         raise ValueError(f"Dataset '{dataset_name}' is not supported.")

--- a/dit/data/__init__.py
+++ b/dit/data/__init__.py
@@ -24,5 +24,6 @@ def create_loader(dataset_name, batch_size, image_size, deterministic=False):
         dataset,
         batch_size=batch_size,
         shuffle=True,
-        generator=generator
+        generator=generator,
+        pin_memory = True
     )

--- a/dit/data/coco.py
+++ b/dit/data/coco.py
@@ -4,13 +4,10 @@ import torch
 from torchvision import transforms
 from PIL import Image
 
-# Load the COCO dataset
-coco_dataset = load_dataset("HuggingFaceM4/COCO", split="train")
-
 # Define the transforms
 def get_transform(image_size):
     return transforms.Compose([
-        transforms.RandomResizedCrop(image_size),
+        transforms.Resize((image_size, image_size)),
         transforms.RandomHorizontalFlip(),
         transforms.Lambda(lambda img: img.convert('RGB')),  # Convert to RGB
         transforms.ToTensor(),
@@ -18,8 +15,8 @@ def get_transform(image_size):
     ])
 
 class CustomCOCODataset(Dataset):
-    def __init__(self, image_size=224):
-        self.dataset = coco_dataset
+    def __init__(self, image_size=512, split = 'train'):
+        self.dataset = load_dataset("HuggingFaceM4/COCO", split=split)
         self.transform = get_transform(image_size)
 
     def __len__(self):
@@ -27,6 +24,10 @@ class CustomCOCODataset(Dataset):
 
     def __getitem__(self, idx):
         image = self.dataset[idx]['image']
+        label = self.dataset[idx]['sentences']['raw']
         if self.transform:
             image = self.transform(image)
-        return image
+        return image, str(label)
+
+
+

--- a/dit/model.py
+++ b/dit/model.py
@@ -118,6 +118,9 @@ class RectFlowTransformer(nn.Module):
     return self.text_embedder.encode_text(*args, **kwargs)
   
   def normalize(self):
+    if self.repa is not None:
+      norm_layer(self.repa.mlp.fc1)
+      norm_layer(self.repa.mlp.fc2)
     self.core.normalize()
 
   def forward(self, x):

--- a/dit/model.py
+++ b/dit/model.py
@@ -18,7 +18,7 @@ from .nn.text_embedder import TextEmbedder
 from .nn.normalization import Norm, RMSNorm, norm_layer, norm_dit_block
 from .nn.repa import REPA
 
-class RectFlowTransformer(nn.Module):
+class RFTCore(nn.Module):
   def __init__(self, config: ModelConfig = ModelConfig()):
     super().__init__()
 
@@ -34,32 +34,66 @@ class RectFlowTransformer(nn.Module):
     self.t_embedder = TimestepEmbedding(d_model)
 
     n_patches = (sample_size // patch_size) ** 2
-    # Seen in repos that init'ing with std = 0.02 is better
-    # You can use abs + rope but often times it's not needed
     self.pos_enc = AbsEmbedding(n_patches, d_model)
 
-    # Shorter way to make many layers
     self.layers = nn.ModuleList([DiTBlock(config) for _ in range(n_layers)])
 
-    # Make some patchify and depatchify functions given the params
     self.patchify = lambda x: eo.rearrange(x, 'b c (n_p_h p_h) (n_p_w p_w) -> b (n_p_h n_p_w) (p_h p_w c)',
-                                           p_h = patch_size, p_w = patch_size)
+                                            p_h=patch_size, p_w=patch_size)
     self.depatchify = lambda x: eo.rearrange(x, 'b (n_p_h n_p_w) (p_h p_w c) -> b c (n_p_h p_h) (n_p_w p_w)',
-                                             p_h = patch_size, p_w = patch_size, n_p_h = sample_size//patch_size)
+                                              p_h=patch_size, p_w=patch_size, n_p_h=sample_size//patch_size)
 
     patch_content = channels * patch_size ** 2
 
     self.proj_in = nn.Linear(patch_content, d_model)
+    if self.config.take_label: self.text_proj = nn.Linear(self.config.text_d_model, d_model)
     self.proj_out = nn.Linear(d_model, patch_content)
     
-    #self.final_norm = RMSNorm(d_model)
-    #self.final_norm = nn.LayerNorm(d_model, elementwise_affine = False, eps = 1.0e-6)
-    self.final_norm  = Norm()
-
+    self.final_norm = Norm()
     self.final_mod = SimpleModulation(d_model)
 
+    truncated_normal_init(self.pos_enc)
+      
+  def normalize(self):
+    norm_layer(self.proj_in)
+    norm_layer(self.proj_out)
+    for layer in self.layers:
+      norm_dit_block(layer)
+
+  def forward(self, x, t, c=None, output_hidden_states=False):
+    if c is not None:
+      c = self.text_proj(c)
+
+    x = self.patchify(x)
+    x = self.proj_in(x)
+    t = self.t_embedder(t)
+    x = x + self.pos_enc(x)
+
+    h = []
+    for layer in self.layers:
+      x = layer(x, t, c)
+      if output_hidden_states:
+        h.append(x)
+
+    x = self.final_norm(x)
+    x = self.final_mod(x, t)
+    x = self.proj_out(x)
+    x = self.depatchify(x)
+
+    if output_hidden_states:
+      return x, h
+    return x
+
+class RectFlowTransformer(nn.Module):
+  def __init__(self, config: ModelConfig = ModelConfig()):
+    super().__init__()
+
+    self.config = config
+
+    self.core = RFTCore(config)
+
     if self.config.take_label:
-      self.text_embedder = TextEmbedder(d_model)
+      self.text_embedder = TextEmbedder(config.d_model)
       freeze(self.text_embedder)
 
     self.vae = None
@@ -67,31 +101,23 @@ class RectFlowTransformer(nn.Module):
         self.vae = VAE()
         freeze(self.vae)
 
-    # Inits
-    for layer in self.layers:
-        pass
-        #truncated_normal_init(layer)
-        #mimetic_init(layer.qkv, layer.out, config.n_heads)
+    self.repa = REPA(self.config)
 
-    truncated_normal_init(self.pos_enc)
-    self.norm = Norm()
-    self.repa = REPA(self.config.d_model, self.config.repa_batch_size, self.config.repa_pool_factor)
+  def parameters(self):
+    return self.core.parameters() # Only return what we need
   
   def encode_text(self, *args, **kwargs):
     return self.text_embedder.encode_text(*args, **kwargs)
   
   def normalize(self):
-    norm_layer(self.proj_in)
-    norm_layer(self.proj_out)
-    for layer in self.layers:
-      norm_dit_block(layer)
+    self.core.normalize()
 
   def forward(self, x):
     if self.config.take_label:
       x, ctx = x # c is list str
       if self.config.cfg_prob > 0:
-          mask = torch.rand(len(ctx)) < self.config.cfg_prob
-          ctx = [c if not m else "" for c, m in zip(ctx, mask)]
+        mask = torch.rand(len(ctx)) < self.config.cfg_prob
+        ctx = [c if not m else "" for c, m in zip(ctx, mask)]
 
       ctx = self.text_embedder.encode_text(ctx)
       ctx = ctx.to(x.dtype).to(x.device)
@@ -101,23 +127,23 @@ class RectFlowTransformer(nn.Module):
 
     x_orig = x.clone()
     if self.vae is not None:
-        with torch.no_grad():
-            x = self.vae.encode(x)
+      with torch.no_grad():
+        x = self.vae.encode(x)
 
     b, c, h, w = x.shape
 
     # prepare target and input
     with torch.no_grad():
-        z = torch.randn_like(x) # Noise we will lerp with
-        t = torch.randn(b, device = x.device, dtype = x.dtype).sigmoid() # log norm timesteps
+      z = torch.randn_like(x) # Noise we will lerp with
+      t = torch.randn(b, device = x.device, dtype = x.dtype).sigmoid() # log norm timesteps
 
-        # exp here means expanded
-        t_exp = eo.repeat(t, 'b -> b c h w', c = c, h = h, w = w) # Makes it the same shape as x and z so we can multiply
+      # exp here means expanded
+      t_exp = eo.repeat(t, 'b -> b c h w', c = c, h = h, w = w) # Makes it the same shape as x and z so we can multiply
 
-        # Based on ODE setup of going t: 0 -> 1 noise -> images
-        # t = 0 should be noise
-        lerpd = x * (1 - t_exp) + z * t_exp
-        target = z-x # Velocity to predict
+      # Based on ODE setup of going t: 0 -> 1 noise -> images
+      # t = 0 should be noise
+      lerpd = x * (1 - t_exp) + z * t_exp
+      target = z-x # Velocity to predict
 
     extra = {}
 
@@ -136,25 +162,7 @@ class RectFlowTransformer(nn.Module):
     return total_loss, extra
 
   def denoise(self, x, t, c = None, output_hidden_states = False):
-    x = self.patchify(x)
-    x = self.proj_in(x)
-
-    t_emb = self.t_embedder(t)
-    h = []
-    for layer in self.layers:
-      x = layer(x, t_emb, c)
-      h.append(x)
-
-    x = self.final_norm(x)
-    x = self.final_mod(x, t_emb)
-    x = self.proj_out(x)
-    x = self.depatchify(x)
-
-    if output_hidden_states:
-      return x,h
-    else:
-      return x
-
+    return self.core(x,t,c,output_hidden_states)
 
 if __name__ == "__main__":
     import torch

--- a/dit/nn/embeddings.py
+++ b/dit/nn/embeddings.py
@@ -85,7 +85,7 @@ class TimestepEmbedding(nn.Module):
     def __init__(self, d_out, d_in = 512):
         super().__init__()
 
-        self.mlp = MLP(d_in, d_out)
+        self.mlp = MLP(d_in, d_out, use_scale = False)
         self.d = d_in # Assume this is even
 
     def forward(self, t):

--- a/dit/nn/mlp.py
+++ b/dit/nn/mlp.py
@@ -21,10 +21,11 @@ class MLP(nn.Module):
     if use_scale:
         self.scale = nn.Parameter(torch.zeros(4*dim))
     self.use_scale = use_scale
+    self.v_scale = dim ** .5
 
   def forward(self, x):
     x = self.fc1(x) 
-    if self.use_scale: x *= (1. + self.scale)[None,None,:]
+    if self.use_scale: x *= (1. + self.scale)[None,None,:] * self.v_scale
     x = self.act(x)
     x = self.fc2(x)
     return x

--- a/dit/nn/mlp.py
+++ b/dit/nn/mlp.py
@@ -28,6 +28,6 @@ class MLP(nn.Module):
   def forward(self, x):
     x = self.fc1(x) 
     if self.use_scale: x *= (1. + self.scale)[None,None,:] * self.v_scale
-    x = self.act(x.half()).to(x.dtype)
+    x = self.act(x)
     x = self.fc2(x)
     return x

--- a/dit/nn/mlp.py
+++ b/dit/nn/mlp.py
@@ -9,10 +9,12 @@ class MLP(nn.Module):
   this model essentially processes each word individually,
   i.e. information flow from input to output is only within words, not between them
   """
-  def __init__(self, dim, dim_out = None, use_scale = True):
+  def __init__(self, dim, dim_out = None, d_middle = None, use_scale = True):
     super().__init__()
     if dim_out is None:
       dim_out = dim
+    if d_middle is None:
+      d_middle = 4 * dim
 
     self.fc1 = nn.Linear(dim, 4 * dim) # hiddden size in transformer MLPs is normally 4x the input size
     self.act = nn.GELU()
@@ -26,6 +28,6 @@ class MLP(nn.Module):
   def forward(self, x):
     x = self.fc1(x) 
     if self.use_scale: x *= (1. + self.scale)[None,None,:] * self.v_scale
-    x = self.act(x)
+    x = self.act(x.half()).to(x.dtype)
     x = self.fc2(x)
     return x

--- a/dit/nn/mlp.py
+++ b/dit/nn/mlp.py
@@ -9,7 +9,7 @@ class MLP(nn.Module):
   this model essentially processes each word individually,
   i.e. information flow from input to output is only within words, not between them
   """
-  def __init__(self, dim, dim_out = None):
+  def __init__(self, dim, dim_out = None, use_scale = True):
     super().__init__()
     if dim_out is None:
       dim_out = dim
@@ -18,8 +18,13 @@ class MLP(nn.Module):
     self.act = nn.GELU()
     self.fc2 = nn.Linear(4 * dim, dim_out)
 
+    if use_scale:
+        self.scale = nn.Parameter(torch.ones(4*dim))
+    self.use_scale = use_scale
+
   def forward(self, x):
-    x = self.fc1(x)
+    x = self.fc1(x) 
+    if self.use_scale: x *= self.scale[None,None,:]
     x = self.act(x)
     x = self.fc2(x)
     return x

--- a/dit/nn/mlp.py
+++ b/dit/nn/mlp.py
@@ -19,12 +19,12 @@ class MLP(nn.Module):
     self.fc2 = nn.Linear(4 * dim, dim_out)
 
     if use_scale:
-        self.scale = nn.Parameter(torch.ones(4*dim))
+        self.scale = nn.Parameter(torch.zeros(4*dim))
     self.use_scale = use_scale
 
   def forward(self, x):
     x = self.fc1(x) 
-    if self.use_scale: x *= self.scale[None,None,:]
+    if self.use_scale: x *= (1. + self.scale)[None,None,:]
     x = self.act(x)
     x = self.fc2(x)
     return x

--- a/dit/nn/modulation.py
+++ b/dit/nn/modulation.py
@@ -2,6 +2,8 @@ import torch
 from torch import nn
 from torchtyping import TensorType
 
+from .normalization import norm
+
 class ModulationOutput:
   def __init__(self, alpha, beta, gamma):
     self.alpha = alpha[:,None] # [b,1,d]
@@ -14,34 +16,57 @@ class ModulationOutput:
   def second_step(self, x):
     return x * self.gamma
 
+class HyperSphereModulation(ModulationOutput):
+  def first_step(self, x):
+    # SLERP x with beta using alpha as an interpolation factor
+    x = norm(x)
+    beta = norm(self.beta)
+    scale = (1. + self.alpha)
+    return norm(x + scale * (beta - x))
+  
+  def second_step(self, x):
+    return norm(x * self.gamma)
+
 class SimpleModulation(nn.Module):
     """
     Simple modulation with jsut shift and scale
     """
-    def __init__(self, dim):
+    def __init__(self, dim, normalized = False):
         super().__init__()
 
         self.act = nn.GELU()
         self.mod_params = nn.Linear(dim, 2 * dim)
+        self.normalized = normalized
     
     def forward(self, x, t):
         t = self.act(t)
         scale, shift = self.mod_params(t).chunk(2,dim=-1)
-        return x * (1 + scale[:,None]) + shift[:,None]
+
+        if self.normalized:
+          return x * (1 + scale[:,None]) + shift[:,None]
+        else:
+          shift = norm(shift)[:,None]
+          scale = (1. + scale)[:,None]
+          return norm(x + scale * (shift - x))
 
 # Makes modulation parameters given t embedding
 class DoubleModBlock(nn.Module):
-  def __init__(self, dim):
+  def __init__(self, dim, normalized = False):
     super().__init__()
 
     self.act = nn.GELU() # Following SD3
     self.fc = nn.Linear(dim, 6 * dim)
+
+    if normalized:
+      self.modulation_cls = HyperSphereModulation
+    else:
+      self.modulation_cls = ModulationOutput
 
   def forward(self, t):
     t = self.act(t)
     params = self.fc(t) # They say an MLP, but I think this isn't needed
     alpha_1, beta_1, gamma_1, alpha_2, beta_2, gamma_2 = params.chunk(6, dim = -1) # Break into 6 parts
     return [
-        ModulationOutput(alpha_1, beta_1, gamma_1),
-        ModulationOutput(alpha_2, beta_2, gamma_2)
+        self.modulation_cls(alpha_1, beta_1, gamma_1),
+        self.modulation_cls(alpha_2, beta_2, gamma_2)
     ]

--- a/dit/nn/normalization.py
+++ b/dit/nn/normalization.py
@@ -18,3 +18,12 @@ class RMSNorm(nn.Module):
         x = x * gain
 
         return x
+
+class Norm(nn.Module):
+    def __init__(self, eps = 1.0e-6):
+        super().__init__()
+        self.eps = eps
+    
+    def forward(self, x):
+        rss = (x.float().pow(2).sum(-1, keepdim = True) + self.eps).rsqrt()
+        return x * rss

--- a/dit/nn/normalization.py
+++ b/dit/nn/normalization.py
@@ -26,12 +26,17 @@ class Norm(nn.Module):
         self.eps = eps
     
     def forward(self, x):
-        return F.normalize(x.float(), p = 2, dim = -1).to(x.dtype)
+        return norm(x)
+        #rss = (x.float().pow(2).sum(-1, keepdim = True) + self.eps).rsqrt()
+        #return x * rss
+    
     
 LayerNorm = lambda dim: nn.LayerNorm(dim, elementwise_affine = False, eps = 1.0e-6)
 
-def norm(x, eps = 1.0e-6):
-    return F.normalize(x.float(), p = 2, dim = -1).to(x.dtype)
+def norm(data):
+    return F.normalize(data.float(), p = 2, dim = -1, eps = 1.0e-6).to(data.dtype)
+    #norm = torch.norm(data.float(), p=2, dim=-1, keepdim=True)
+    #return data / (norm.to(data.dtype) + 1e-6)  # Adding small epsilon to avoid division by zero
 
 def norm_layer(module : nn.Module):
     """

--- a/dit/nn/normalization.py
+++ b/dit/nn/normalization.py
@@ -27,3 +27,5 @@ class Norm(nn.Module):
     def forward(self, x):
         rss = (x.float().pow(2).sum(-1, keepdim = True) + self.eps).rsqrt()
         return x * rss
+    
+LayerNorm = lambda dim: nn.LayerNorm(dim, elementwise_affine = False, eps = 1.0e-6)

--- a/dit/nn/normalization.py
+++ b/dit/nn/normalization.py
@@ -1,5 +1,6 @@
 import torch
 from torch import nn
+import torch.nn.functional as F
 
 from torchtyping import TensorType
 
@@ -25,14 +26,12 @@ class Norm(nn.Module):
         self.eps = eps
     
     def forward(self, x):
-        rss = (x.float().pow(2).sum(-1, keepdim = True) + self.eps).rsqrt()
-        return x * rss
+        return F.normalize(x.float(), p = 2, dim = -1).to(x.dtype)
     
 LayerNorm = lambda dim: nn.LayerNorm(dim, elementwise_affine = False, eps = 1.0e-6)
 
-def norm(data):
-    norm = torch.norm(data.float(), p=2, dim=-1, keepdim=True)
-    return data / (norm.to(data.dtype) + 1e-6)  # Adding small epsilon to avoid division by zero
+def norm(x, eps = 1.0e-6):
+    return F.normalize(x.float(), p = 2, dim = -1).to(x.dtype)
 
 def norm_layer(module : nn.Module):
     """

--- a/dit/nn/repa.py
+++ b/dit/nn/repa.py
@@ -6,7 +6,7 @@ from torchtyping import TensorType
 import einops as eo
 
 from .mlp import MLP
-from .configs import ModelConfig
+from ..configs import ModelConfig
 from ..utils import freeze
 
 def dino_proc(x: TensorType["b", "c", "h", "w"]):
@@ -44,7 +44,7 @@ class REPA(nn.Module):
         self.dino = AutoModel.from_pretrained(dino_path)
         self.dino.to(device='cuda',dtype=torch.half)
         self.mlp = MLP(
-            config.d_model * (pool_factor ** 2),
+            config.d_model * (self.pool_factor ** 2),
             dim_out=self.dino.config.hidden_size,
             use_scale = False,
             d_middle = config.d_model * 4

--- a/dit/nn/repa.py
+++ b/dit/nn/repa.py
@@ -1,0 +1,95 @@
+from transformers import AutoModel, AutoProcessor
+import torch
+from torch import nn
+import torch.nn.functional as F
+from torchtyping import TensorType
+import einops as eo
+
+from .mlp import MLP
+from .configs import ModelConfig
+from ..utils import freeze
+
+def dino_proc(x: TensorType["b", "c", "h", "w"]):
+    """
+    DINO processor as a function
+    """
+    # Convert from [-1, 1] to [0, 1]
+    x = (x + 1) / 2
+
+    # Resize
+    x = F.interpolate(x, size=(224, 224), mode='bilinear', align_corners=False)
+
+    # Rescale
+    x = x * 0.00392156862745098  # This is the rescale_factor
+
+    # Normalize
+    mean = torch.tensor([0.485, 0.456, 0.406]).view(1, 3, 1, 1).to(x.device)
+    std = torch.tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1).to(x.device)
+    x = (x - mean) / std
+
+    return x
+
+# This only works for a factor of 2 currently
+def patch_pool(x : TensorType["b", "n", "d"], config : ModelConfig):
+    #x = eo.rearrange(x, 'b (n_p_h n_p_w) d -> b n_p_h n_p_w d', n_p_h = config.sample_size//config.patch_size)
+    #x = eo.rearrange(x, '')
+    return x
+
+class REPA(nn.Module):
+    def __init__(self, config : ModelConfig, dino_path = "facebook/dinov2-small"):
+        super().__init__()
+
+        self.pool_factor = config.repa_pool_factor
+
+        self.dino = AutoModel.from_pretrained(dino_path)
+        self.dino.to(device='cuda',dtype=torch.half)
+        self.mlp = MLP(
+            config.d_model * (pool_factor ** 2),
+            dim_out=self.dino.config.hidden_size,
+            use_scale = False,
+            d_middle = config.d_model * 4
+        )
+        self.batch_size = config.repa_batch_size
+        
+        self.patch_pool = None
+        if self.pool_factor > 1:
+            self.patch_pool = lambda x: patch_pool(x, config)
+    
+        freeze(self.dino)
+
+    def to(self, *args, **kwargs): # don't touch dino
+        self.mlp.to(*args, **kwargs)
+
+    @torch.no_grad()
+    def dino_features(self, x):
+        # x is [b,c,h,w] [-1,1]
+        inputs = dino_proc(x.half().cuda())
+        input_batches = inputs.split(self.batch_size)
+
+        h_all = []
+        for batch in input_batches:
+            h = self.dino(pixel_values=batch, output_hidden_states = True).hidden_states[-2][:,1:] # Skip CLS
+            h_all.append(h)
+        
+        h_all = torch.cat(h_all)
+
+        return h_all.to(x.dtype)
+
+    def forward(self, x, features):
+        # x [b,c,h,w]
+        # features [b,n,d]
+
+        if self.pool_factor > 1:
+            patch_p
+
+        h = self.dino_features(x)
+        h_rft = self.mlp(features)
+        # now both [b,n,d] in the same space
+
+        h = F.normalize(h, p = 2, dim = -1)
+        h_rft = F.normalize(h_rft, p = 2, dim = -1)
+
+        cos_sims = torch.einsum('bnd,bnd->bn', h, h_rft)
+        return -cos_sims.mean() # maximize cos_sims -> minimize -cos_sims
+
+

--- a/dit/nn/text_embedder.py
+++ b/dit/nn/text_embedder.py
@@ -9,6 +9,9 @@ class TextEmbedder(nn.Module):
         self.model = CLIPTextModel.from_pretrained("openai/clip-vit-base-patch32")
         self.tokenizer = CLIPTokenizer.from_pretrained("openai/clip-vit-base-patch32")
 
+        self.cuda()
+        self.half()
+
     def tokenize(self, text_list):
         return self.tokenizer(text_list, padding='max_length', max_length = 77, truncation=True, return_tensors="pt")
 

--- a/dit/nn/text_embedder.py
+++ b/dit/nn/text_embedder.py
@@ -8,10 +8,6 @@ class TextEmbedder(nn.Module):
 
         self.model = CLIPTextModel.from_pretrained("openai/clip-vit-base-patch32")
         self.tokenizer = CLIPTokenizer.from_pretrained("openai/clip-vit-base-patch32")
-        self.proj = nn.Linear(self.model.config.hidden_size, dim)
-
-        self.cuda()
-        self.half()
 
     def tokenize(self, text_list):
         return self.tokenizer(text_list, padding='max_length', max_length = 77, truncation=True, return_tensors="pt")
@@ -22,7 +18,7 @@ class TextEmbedder(nn.Module):
 
         outputs = self.model(input_ids=input_ids, attention_mask=attention_mask, output_hidden_states = True)
         hidden_states = outputs.hidden_states[-2]  # Second last hidden state
-        return self.proj(hidden_states)
+        return hidden_states
 
     @torch.no_grad()
     def encode_text(self, text_list):

--- a/dit/nn/transformers.py
+++ b/dit/nn/transformers.py
@@ -153,7 +153,7 @@ class DiTBlock(nn.Module):
     flash = config.flash
     cross_attn = config.take_label
 
-    self.mod = DoubleModBlock(d_model)
+    self.mod = DoubleModBlock(d_model, normalized = True)
 
     self.attn = Attn(n_heads, d_model, flash, cross_attn)
     self.mlp = MLP(d_model)
@@ -185,8 +185,8 @@ class DiTBlock(nn.Module):
     #x = self.norm_1(x)
     #x = mod1.first_step(x)
     
-    x = self.norm(mod1.first_step(self.norm(x)))
-    #x = mod1.first_step(x)
+    #x = self.norm(mod1.first_step(self.norm(x)))
+    x = mod1.first_step(x)
 
     if self.cross:
         attn_out = self.attn(x, c)
@@ -194,7 +194,7 @@ class DiTBlock(nn.Module):
         attn_out = self.attn(x)
     
 
-    attn_out = self.norm(mod1.second_step(self.norm(attn_out))) # h_A
+    attn_out = mod1.second_step(self.norm(attn_out)) # h_A
     #attn_out = mod1.second_step(attn_out)
 
     x = self.norm(resid_1 + self.get_alpha_attn() * (attn_out - resid_1))
@@ -202,12 +202,12 @@ class DiTBlock(nn.Module):
 
     resid_2 = x.clone()
 
-    x = self.norm(mod2.first_step(self.norm(x)))
-    #x = mod2.first_step(self.norm_2(x))
+    #x = self.norm(mod2.first_step(self.norm(x)))
+    x = mod2.first_step(x)
     
     x = self.mlp(x)
 
-    x = self.norm(mod2.second_step(x)) # h_M
+    x = mod2.second_step(x) # h_M
     #x = mod2.second_step(x)
 
     x = self.norm(resid_2 + self.get_alpha_mlp() * (x - resid_2))

--- a/dit/sampling.py
+++ b/dit/sampling.py
@@ -60,7 +60,7 @@ class CFGSampler:
     def sample(self, n_samples = None, model = None, prompts = None):
         if n_samples is None:
             n_samples = len(prompts)
-            
+
         n_steps = self.config.n_steps
         guidance_scale = self.config.cfg_scale
 
@@ -124,5 +124,8 @@ def to_wandb_image(x : TensorType["c", "h", "w"], caption : str = ""):
     x = x.detach().cpu().numpy()
     return wandb.Image(x, caption = caption)
 
-def to_wandb_batch(x):
-    return [to_wandb_image(x_i) for x_i in x]
+def to_wandb_batch(x, captions = None):
+    if captions is None:
+        return [to_wandb_image(x_i) for x_i in x]
+    else:
+        return [to_wandb_image(x_i, caption) for (x_i, caption) in zip(x, captions)]

--- a/dit/sampling.py
+++ b/dit/sampling.py
@@ -57,7 +57,10 @@ class CFGSampler:
         self.config = config
 
     @torch.no_grad()
-    def sample(self, n_samples, model, prompts):
+    def sample(self, n_samples = None, model = None, prompts = None):
+        if n_samples is None:
+            n_samples = len(prompts)
+            
         n_steps = self.config.n_steps
         guidance_scale = self.config.cfg_scale
 
@@ -82,11 +85,6 @@ class CFGSampler:
         device = next(model.parameters()).device
         dtype = next(model.parameters()).dtype
 
-        flip_back = False
-        if dtype == torch.float:
-            model.half()
-            dtype = torch.half
-
         noisy = noisy.to(device=device, dtype=dtype)
         timesteps = timesteps.to(device=device, dtype=dtype)
         sigmas = sigmas.to(device=device, dtype=dtype)
@@ -108,9 +106,6 @@ class CFGSampler:
             
             # 5. Update noisy
             noisy += v * dt
-        
-        if flip_back:
-            model.float()
 
         if model.vae is None:
             return noisy

--- a/dit/soap.py
+++ b/dit/soap.py
@@ -1,0 +1,423 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+from itertools import chain
+
+# Parts of the code are modifications of Pytorch's AdamW optimizer
+# Parts of the code are modifications of code from https://github.com/jiaweizzhao/GaLore/blob/master/galore_torch/galore_projector.py
+# From https://github.com/nikhilvyas/SOAP/blob/main/soap.py
+
+class SOAP(optim.Optimizer):
+    """
+    Implements SOAP algorithm (https://arxiv.org/abs/2409.11321).
+
+    Parameters:
+        params (`Iterable[nn.parameter.Parameter]`):
+            Iterable of parameters to optimize or dictionaries defining parameter groups.
+        lr (`float`, *optional*, defaults to 0.003):
+            The learning rate to use.
+        betas (`Tuple[float,float]`, *optional*, defaults to `(0.95, 0.95)`):
+            Adam's betas parameters (b1, b2).
+        shampoo_beta (`float`, *optional*, defaults to -1):
+            If >= 0, use this beta for the preconditioner (L and R in paper, state['GG'] below) moving average instead of betas[1].
+        eps (`float`, *optional*, defaults to 1e-08):
+            Adam's epsilon for numerical stability.
+        weight_decay (`float`, *optional*, defaults to 0.01): weight decay coefficient.
+        precondition_frequency (`int`, *optional*, defaults to 10):
+            How often to update the preconditioner.
+        max_precond_dim (`int`, *optional*, defaults to 10000):
+            Maximum dimension of the preconditioner.
+            Set to 10000, so that we exclude most common vocab sizes while including layers.
+        merge_dims (`bool`, *optional*, defaults to `False`):
+            Whether or not to merge dimensions of the preconditioner.
+        precondition_1d (`bool`, *optional*, defaults to `False`):
+            Whether or not to precondition 1D gradients.
+        normalize_grads (`bool`, *optional*, defaults to `False`):
+            Whether or not to normalize gradients per layer. 
+            Helps at large precondition_frequency (~100 in our experiments), 
+            but hurts performance at small precondition_frequency (~10 in our experiments).
+        data_format (`str`, *optional*, defaults to `channels_first`):
+            Data format of the input for convolutional layers.
+            Should be "channels_last" for data_format of NHWC and "channels_first" for NCHW.
+        correct_bias (`bool`, *optional*, defaults to `True`):
+            Whether or not to use bias correction in Adam.
+    """
+
+    def __init__(
+        self,
+        params,
+        lr: float = 3e-3,
+        betas=(0.95, 0.95),
+        shampoo_beta: float= -1,
+        eps: float = 1e-8,
+        weight_decay: float = 0.01,
+        precondition_frequency: int=50,
+        max_precond_dim: int=10000, # 
+        merge_dims: bool = False, # Merge dimensions till the product of the dimensions is less than or equal to max_precond_dim.
+        precondition_1d: bool = False,
+        normalize_grads: bool = False,
+        data_format: str = "channels_first",
+        correct_bias: bool = True,
+    ):
+        defaults = {
+            "lr": lr,
+            "betas": betas,
+            "shampoo_beta": shampoo_beta,
+            "eps": eps,
+            "weight_decay": weight_decay,
+            "precondition_frequency": precondition_frequency,
+            "max_precond_dim": max_precond_dim,
+            "merge_dims": merge_dims,
+            "precondition_1d": precondition_1d,
+            "normalize_grads": normalize_grads,
+            "correct_bias": correct_bias,
+        }
+        super().__init__(params, defaults)
+        self._data_format = data_format
+        
+    def merge_dims(self, grad, max_precond_dim):
+        """
+        Merges dimensions of the gradient tensor till the product of the dimensions is less than or equal to max_precond_dim.
+        """
+        assert self._data_format in ["channels_first", "channels_last"]
+        if self._data_format == "channels_last" and grad.dim() == 4:
+            grad = grad.permute(0, 3, 1, 2)
+        shape = grad.shape
+        new_shape = []
+        
+        curr_shape = 1
+        for sh in shape:
+            temp_shape = curr_shape * sh
+            if temp_shape > max_precond_dim:
+                if curr_shape > 1:
+                    new_shape.append(curr_shape)
+                    curr_shape = sh
+                else:
+                    new_shape.append(sh)
+                    curr_shape = 1
+            else:
+                curr_shape = temp_shape
+        
+        if curr_shape > 1 or len(new_shape)==0:
+            new_shape.append(curr_shape)
+        
+        new_grad = grad.reshape(new_shape)
+        return new_grad               
+
+    @torch.no_grad()
+    def step(self, closure = None):
+        """
+        Performs a single optimization step.
+
+        Arguments:
+            closure (`Callable`, *optional*): A closure that reevaluates the model and returns the loss.
+        """
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad
+
+                state = self.state[p]
+                
+                if "step" not in state:
+                    state["step"] = 0 
+                    
+                # State initialization
+                if "exp_avg" not in state:
+                    # Exponential moving average of gradient values
+                    state["exp_avg"] = torch.zeros_like(grad)
+                    # Exponential moving average of squared gradient values
+                    state["exp_avg_sq"] = torch.zeros_like(grad)
+                
+                if 'Q' not in state:
+                    self.init_preconditioner(
+                        grad,
+                        state,
+                        precondition_frequency=group['precondition_frequency'],
+                        precondition_1d=group['precondition_1d'],
+                        shampoo_beta=(group['shampoo_beta'] if group['shampoo_beta'] >= 0 else group["betas"][1]),
+                        max_precond_dim=group['max_precond_dim'],
+                        merge_dims=group["merge_dims"],
+                    )
+                    self.update_preconditioner(grad, state,
+                                               max_precond_dim=group['max_precond_dim'],
+                                               merge_dims=group["merge_dims"],
+                                               precondition_1d=group["precondition_1d"])
+                    continue # first step is skipped so that we never use the current gradients in the projection.
+                
+                # Projecting gradients to the eigenbases of Shampoo's preconditioner 
+                # i.e. projecting to the eigenbases of matrices in state['GG']
+                grad_projected = self.project(grad, state, merge_dims=group["merge_dims"], 
+                                              max_precond_dim=group['max_precond_dim'])
+
+                exp_avg, exp_avg_sq = state["exp_avg"], state["exp_avg_sq"]
+                beta1, beta2 = group["betas"]
+
+                state["step"] += 1
+
+                # Decay the first and second moment running average coefficient
+                # In-place operations to update the averages at the same time
+                exp_avg.mul_(beta1).add_(grad, alpha=(1.0 - beta1))
+                exp_avg_sq.mul_(beta2).add_(grad_projected.square(), alpha=(1.0 - beta2))
+
+                denom = exp_avg_sq.sqrt().add_(group["eps"])
+                
+                # Projecting the exponential moving average of gradients to the eigenbases of Shampoo's preconditioner 
+                # i.e. projecting to the eigenbases of matrices in state['GG']
+                exp_avg_projected = self.project(exp_avg, state, merge_dims=group["merge_dims"],
+                                                 max_precond_dim=group['max_precond_dim'])
+                
+                step_size = group["lr"]
+                if group["correct_bias"]:
+                    bias_correction1 = 1.0 - beta1 ** (state["step"])
+                    bias_correction2 = 1.0 - beta2 ** (state["step"])
+                    step_size = step_size * (bias_correction2 ** .5) / bias_correction1
+
+                # Projecting back the preconditioned (by Adam) exponential moving average of gradients
+                # to the original space
+                norm_grad = self.project_back(exp_avg_projected / denom, state, merge_dims=group["merge_dims"],
+                                                 max_precond_dim=group['max_precond_dim'])
+
+                if group["normalize_grads"]:
+                    norm_grad = norm_grad / (1e-30+torch.mean(norm_grad**2)**0.5)
+                
+                p.add_(norm_grad, alpha=-step_size)
+                
+
+                # From AdamW code: Just adding the square of the weights to the loss function is *not*
+                # the correct way of using L2 regularization/weight decay with Adam,
+                # since that will interact with the m and v parameters in strange ways.
+                #
+                # Instead we want to decay the weights in a manner that doesn't interact
+                # with the m/v parameters. This is equivalent to adding the square
+                # of the weights to the loss with plain (non-momentum) SGD.
+                # Add weight decay at the end (fixed version)
+                if group["weight_decay"] > 0.0:
+                    p.add_(p, alpha=(-group["lr"] * group["weight_decay"]))
+                    
+                # Update is done after the gradient step to avoid using current gradients in the projection.
+                self.update_preconditioner(grad, state, 
+                                               max_precond_dim=group['max_precond_dim'],
+                                               merge_dims=group["merge_dims"],
+                                               precondition_1d=group["precondition_1d"])
+        
+        return loss
+    
+    def init_preconditioner(self, grad, state, precondition_frequency=10, 
+                            shampoo_beta=0.95, max_precond_dim=10000, precondition_1d=False,
+                            merge_dims=False):
+        """
+        Initializes the preconditioner matrices (L and R in the paper).
+        """
+        state['GG'] = [] # Will hold all the preconditioner matrices (L and R in the paper).
+        if grad.dim() == 1:
+            if not precondition_1d or grad.shape[0] > max_precond_dim:
+                state['GG'].append([])
+            else:
+                state['GG'].append(torch.zeros(grad.shape[0], grad.shape[0], device=grad.device))
+        else:
+            if merge_dims:
+                grad = self.merge_dims(grad, max_precond_dim)
+
+            for sh in grad.shape:
+                if sh > max_precond_dim:
+                    state['GG'].append([])
+                else:
+                    state['GG'].append(torch.zeros(sh, sh, device=grad.device))
+                    
+        state['Q'] = None # Will hold all the eigenbases of the preconditioner.
+        state['precondition_frequency'] = precondition_frequency
+        state['shampoo_beta'] = shampoo_beta          
+        
+    def project(self, grad, state, merge_dims=False, max_precond_dim=10000):
+        """
+        Projects the gradient to the eigenbases of the preconditioner.
+        """
+        original_shape = grad.shape
+        if merge_dims:
+            if grad.dim() == 4 and self._data_format == 'channels_last':
+                permuted_shape = grad.permute(0, 3, 1, 2).shape
+            grad = self.merge_dims(grad, max_precond_dim)
+
+        for mat in state['Q']:
+            if len(mat) > 0:
+                grad = torch.tensordot(
+                        grad,
+                        mat,
+                        dims=[[0], [0]],
+                    )
+            else:
+                permute_order = list(range(1, len(grad.shape))) + [0]
+                grad = grad.permute(permute_order)
+        
+        if merge_dims:
+            if self._data_format == 'channels_last' and len(original_shape) == 4:
+                grad = grad.reshape(permuted_shape).permute(0, 2, 3, 1)
+            else:
+                grad = grad.reshape(original_shape)
+        return grad
+        
+    def update_preconditioner(self, grad, state, 
+                              max_precond_dim=10000, merge_dims=False, precondition_1d=False):
+        """
+        Updates the preconditioner matrices and the eigenbases (L, R, Q_L, Q_R in the paper).
+        """
+        if grad.dim() == 1:
+            if precondition_1d and grad.shape[0] <= max_precond_dim:
+                state['GG'][0].lerp_(grad.unsqueeze(1) @ grad.unsqueeze(0), 1-state['shampoo_beta'])
+        else:
+            if merge_dims:
+                new_grad = self.merge_dims(grad, max_precond_dim)
+                for idx, sh in enumerate(new_grad.shape):
+                    if sh <= max_precond_dim:
+                        outer_product = torch.tensordot(
+                                new_grad,
+                                new_grad,
+                                dims=[[*chain(range(idx), range(idx + 1, len(new_grad.shape)))]] * 2,
+                            )
+                        state['GG'][idx].lerp_(outer_product, 1-state['shampoo_beta'])
+            else:
+                for idx, sh in enumerate(grad.shape):
+                    if sh <= max_precond_dim:
+                        outer_product = torch.tensordot(
+                                grad,
+                                grad,
+                                # Contracts across all dimensions except for k.
+                                dims=[[*chain(range(idx), range(idx + 1, len(grad.shape)))]] * 2,
+                            )
+                        state['GG'][idx].lerp_(outer_product, 1-state['shampoo_beta'])
+                     
+        if state['Q'] is None:
+            state['Q'] = self.get_orthogonal_matrix(state['GG'])
+        if state['step'] > 0 and state['step'] % state['precondition_frequency'] == 0:
+            state['Q'] = self.get_orthogonal_matrix_QR(state, max_precond_dim, merge_dims)           
+
+    def project_back(self, grad, state, merge_dims=False, max_precond_dim=10000):
+        """
+        Projects the gradient back to the original space.
+        """
+        original_shape = grad.shape
+        if merge_dims:
+            if self._data_format == 'channels_last' and grad.dim() == 4:
+                permuted_shape = grad.permute(0, 3, 1, 2).shape
+            grad = self.merge_dims(grad, max_precond_dim)
+        for mat in state['Q']:
+            if len(mat) > 0:
+                grad = torch.tensordot(
+                        grad,
+                        mat,
+                        dims=[[0], [1]],
+                    )
+            else:
+                permute_order = list(range(1, len(grad.shape))) + [0]
+                grad = grad.permute(permute_order)
+                
+        if merge_dims:
+            if self._data_format == 'channels_last' and len(original_shape) == 4:
+                grad = grad.reshape(permuted_shape).permute(0, 2, 3, 1)
+            else:
+                grad = grad.reshape(original_shape)
+        return grad
+        
+
+    def get_orthogonal_matrix(self, mat):
+        """
+        Computes the eigenbases of the preconditioner using torch.linalg.eigh decomposition.
+        """
+        matrix = []
+        for m in mat:
+            if len(m) == 0:
+                matrix.append([])
+                continue
+            if m.data.dtype != torch.float:
+                float_data = False
+                original_type = m.data.dtype
+                original_device = m.data.device
+                matrix.append(m.data.float())
+            else:
+                float_data = True
+                matrix.append(m.data)
+        
+        final = []
+        for m in matrix:
+            if len(m) == 0:
+                final.append([])
+                continue
+            try:
+                _, Q = torch.linalg.eigh(m+1e-30*torch.eye(m.shape[0], device=m.device))
+            except:
+                _, Q = torch.linalg.eigh(m.to(torch.float64)+1e-30*torch.eye(m.shape[0], device=m.device))
+                Q = Q.to(m.dtype)
+            Q = torch.flip(Q, [1])
+
+            if not float_data:
+                Q = Q.to(original_device).type(original_type)
+            final.append(Q)
+        return final
+        
+
+    def get_orthogonal_matrix_QR(self, state, max_precond_dim=10000, merge_dims=False):
+        """
+        Computes the eigenbases of the preconditioner using one round of power iteration 
+        followed by torch.linalg.qr decomposition.
+        """
+        precond_list = state['GG']
+        orth_list = state['Q']
+
+        matrix = []
+        orth_matrix = []
+        for m,o in zip(precond_list, orth_list):
+            if len(m) == 0:
+                matrix.append([])
+                orth_matrix.append([])
+                continue
+            if m.data.dtype != torch.float:
+                float_data = False
+                original_type = m.data.dtype
+                original_device = m.data.device
+                matrix.append(m.data.float())
+                orth_matrix.append(o.data.float())
+            else:
+                float_data = True
+                matrix.append(m.data.float())
+                orth_matrix.append(o.data.float())
+        
+        orig_shape = state['exp_avg_sq'].shape
+        if self._data_format == 'channels_last' and len(orig_shape) == 4:
+            permuted_shape = state['exp_avg_sq'].permute(0, 3, 1, 2).shape
+        if merge_dims:
+            exp_avg_sq = self.merge_dims(state['exp_avg_sq'], max_precond_dim)
+        else:
+            exp_avg_sq = state['exp_avg_sq']
+            
+        final = []
+        for ind, (m,o) in enumerate(zip(matrix, orth_matrix)):
+            if len(m)==0:
+                final.append([])
+                continue
+            est_eig = torch.diag(o.T @ m @ o)
+            sort_idx = torch.argsort(est_eig, descending=True)
+            exp_avg_sq = exp_avg_sq.index_select(ind, sort_idx)
+            o = o[:,sort_idx]
+            power_iter = m @ o
+            Q, _ = torch.linalg.qr(power_iter)
+
+            if not float_data:
+                Q = Q.to(original_device).type(original_type)
+            final.append(Q)
+        
+        if merge_dims:
+            if self._data_format == 'channels_last' and len(orig_shape) == 4:
+                exp_avg_sq = exp_avg_sq.reshape(permuted_shape).permute(0, 2, 3, 1)
+            else:
+                exp_avg_sq = exp_avg_sq.reshape(orig_shape)
+                
+        state['exp_avg_sq'] = exp_avg_sq
+        return final

--- a/dit/trainer.py
+++ b/dit/trainer.py
@@ -139,8 +139,10 @@ class Trainer:
         self.ema = EMA(
             self.accelerator.unwrap_model(model),
             beta = 0.9999,
-            update_after_step = 100,
-            update_every = 1
+            update_after_step = 10,
+            update_every = 1,
+            ignore_names = {'repa', 'vae', 'text_embedder'},
+            coerce_dtype = True
         )
 
         # load checkpoint if we want to 
@@ -209,12 +211,10 @@ class Trainer:
                         self.save(self.total_step_counter)
                     if should['val'] and validator is not None:
                         self.ema.ema_model.eval()
-                        #val_loss = validator(self.ema.ema_model)
+                        val_loss = validator(self.ema.ema_model)
                         pick_score = scorer(sampler, self.ema.ema_model)
                         self.ema.ema_model.train()
-                        #print(val_loss)
-                        print(pick_score)
-                        exit()
+                        
                         wandb.log({
                             'validation_loss' : val_loss,
                             'pick_score' : pick_score

--- a/dit/trainer.py
+++ b/dit/trainer.py
@@ -106,7 +106,7 @@ class Trainer:
 
                     if self.accelerator.sync_gradients:
                         self.total_step_counter += 1
-                        if self.total_step_counter % self.config.normalize_every == 0: self.accelerator.unwrap_model(model).normalize()
+                        self.accelerator.unwrap_model(model).normalize()
                         ema.update()
 
                     should = self.get_should()

--- a/dit/trainer.py
+++ b/dit/trainer.py
@@ -202,7 +202,10 @@ class Trainer:
                             wandb_dict["learning_rate"] = scheduler.get_last_lr()[0]
                         if should['sample']:
                             n_samples = self.config.n_samples
-                            images = to_wandb_batch(sampler.sample(n_samples, self.ema.ema_model, self.config.sample_prompts))
+                            images = to_wandb_batch(
+                                sampler.sample(n_samples, self.ema.ema_model, self.config.sample_prompts),
+                                self.config.sample_prompts
+                            )
                             wandb_dict.update({
                                 "samples": images
                             })

--- a/dit/trainer.py
+++ b/dit/trainer.py
@@ -98,13 +98,16 @@ class Trainer:
 
                     if self.accelerator.sync_gradients:
                         if self.config.grad_clip > 0: self.accelerator.clip_grad_norm_(model.parameters(), self.config.grad_clip)
-                        self.total_step_counter += 1
-                        ema.update()
 
                     opt.step()
                     if scheduler:
                         scheduler.step()
                     opt.zero_grad()
+
+                    if self.accelerator.sync_gradients:
+                        self.total_step_counter += 1
+                        self.accelerator.unwrap_model(model).normalize()
+                        ema.update()
 
                     should = self.get_should()
                     if self.logging_config is not None and should['log'] or should['sample']:

--- a/dit/utils.py
+++ b/dit/utils.py
@@ -65,7 +65,8 @@ def get_scheduler_cls(scheduler_name: str):
         ValueError: If an invalid scheduler name is provided.
     """
     scheduler_map = {
-        "CosineDecayAfterWarmup": CosineDecayAfterWarmup
+        "CosineDecayAfterWarmup": CosineDecayAfterWarmup,
+        "CosineDecay": CosineDecay
     }
 
     scheduler_cls = scheduler_map.get(scheduler_name)
@@ -95,6 +96,23 @@ class CosineDecayAfterWarmup(_LRScheduler):
             # Constant minimum learning rate
             return [self.eta_min for _ in self.base_lrs]
 
+class CosineDecay(_LRScheduler):
+    def __init__(self, optimizer, T_max, eta_min, last_epoch=-1):
+        self.T_max = T_max
+        self.eta_min = eta_min
+        super(CosineDecay, self).__init__(optimizer, last_epoch)
+
+    def get_lr(self):
+        if self.last_epoch < self.T_max:
+            # Cosine decay
+            progress = self.last_epoch / self.T_max
+            return [self.eta_min + (base_lr - self.eta_min) *
+                    (1 + math.cos(math.pi * progress)) / 2
+                    for base_lr in self.base_lrs]
+        else:
+            # Constant minimum learning rate
+            return [self.eta_min for _ in self.base_lrs]
+            
 import time
 
 class Stopwatch:

--- a/dit/utils.py
+++ b/dit/utils.py
@@ -199,3 +199,10 @@ def normal_init(module: nn.Module, std: float = 0.02):
     """
     for p in module.parameters():
         nn.init.normal_(p, mean=0.0, std=std)
+
+# Optimizers stuff
+from .soap import SOAP
+
+def get_extra_optimizer(name):
+    if name.lower() == "soap":
+        return SOAP

--- a/dit/vae.py
+++ b/dit/vae.py
@@ -6,7 +6,7 @@ class VAE(nn.Module):
     def __init__(self, force_batch_size = 16):
         super().__init__()
 
-        self.model = AutoencoderTiny.from_pretrained("madebyollin/taef1", torch_dtype = torch.half)
+        self.model = AutoencoderTiny.from_pretrained("madebyollin/taesdxl")#taef1", torch_dtype = torch.half)
         self.model.cuda()
         self.model.half()
 

--- a/dit/vae.py
+++ b/dit/vae.py
@@ -3,10 +3,10 @@ from torch import nn
 from diffusers import AutoencoderTiny
 
 class VAE(nn.Module):
-    def __init__(self, force_batch_size = 16):
+    def __init__(self, path = "madebyollin/taesdxl", force_batch_size = 16):
         super().__init__()
 
-        self.model = AutoencoderTiny.from_pretrained("madebyollin/taesdxl")#taef1", torch_dtype = torch.half)
+        self.model = AutoencoderTiny.from_pretrained(path)#taef1", torch_dtype = torch.half)
         self.model.cuda()
         self.model.half()
 

--- a/dit/vae.py
+++ b/dit/vae.py
@@ -7,6 +7,8 @@ class VAE(nn.Module):
         super().__init__()
 
         self.model = AutoencoderTiny.from_pretrained(path)#taef1", torch_dtype = torch.half)
+        self.model.cuda()
+        self.model.half()
 
         self.force_batch_size = force_batch_size
     

--- a/dit/vae.py
+++ b/dit/vae.py
@@ -7,8 +7,6 @@ class VAE(nn.Module):
         super().__init__()
 
         self.model = AutoencoderTiny.from_pretrained(path)#taef1", torch_dtype = torch.half)
-        self.model.cuda()
-        self.model.half()
 
         self.force_batch_size = force_batch_size
     

--- a/dit/validation.py
+++ b/dit/validation.py
@@ -57,9 +57,8 @@ class PickScorer:
         text_emb = self.model.get_text_features(input_ids = inputs.input_ids, attention_mask = inputs.attention_mask)
         text_emb = F.normalize(text_emb, p = 2, dim = -1)
 
-        scores = self.model.logit_scale.exp() * (text_emb @ img_emb.T)
-        scores = scores.diag().sum().item()
-        return scores
+        cos_sims = torch.einsum('bd,bd->b', img_emb, text_emb)
+        return cos_sims.sum()
 
     @torch.no_grad()
     def __call__(self, sampler, model):
@@ -79,7 +78,7 @@ class PickScorer:
 
             
             score = self.call_pickscore(prompt_batch, pil_images)
-            pick_score_total += score
+            pick_score_total += score.item()
 
             # Free up CUDA memory
             del images

--- a/dit/validation.py
+++ b/dit/validation.py
@@ -1,0 +1,109 @@
+import torch
+import torch.nn.functional as F
+
+from transformers import AutoProcessor, AutoModel
+from tqdm import tqdm
+from PIL import Image
+
+from .data import create_loader
+
+class Validator:
+    def __init__(self, validation_loader, val_batch_size : int, total_size = 10000):
+        self.loader = validation_loader
+        self.total_size = total_size
+        self.b_size = val_batch_size
+
+    @torch.no_grad()
+    def __call__(self, model):
+        total_loss = 0.
+        n_samples = 0
+        print("Validating...")
+        for batch in tqdm(self.loader, total=self.total_size // self.b_size):
+            loss, extra = model(batch)
+            total_loss += loss.item()
+
+            n_samples += self.b_size
+            if n_samples >= self.total_size:
+                break
+
+        return loss.item() / self.total_size
+
+class PickScorer:
+    def __init__(self, batch_size : int = 256, n_samples : int = None, device = 'cuda'):
+        self.proc = AutoProcessor.from_pretrained("laion/CLIP-ViT-H-14-laion2B-s32B-b79K")
+        self.model = AutoModel.from_pretrained("yuvalkirstain/PickScore_v1")
+
+        self.model.to(device=device,dtype=torch.half)
+
+        self.batch_size = batch_size
+        self.n_samples = batch_size if n_samples is None else n_samples 
+        self.device = device
+
+        # Just get prompts from MSCOCO labels
+        loader = create_loader('coco', self.n_samples, 64, deterministic=True)
+        _, self.prompts = next(iter(loader))
+
+    @torch.no_grad()
+    def call_pickscore(self, prompts, images):
+        inputs = self.proc(
+            images = images,
+            text=prompts,
+            padding = 'max_length', truncation = True, max_length = 77, return_tensors='pt'
+        ).to(device='cuda')
+
+        img_emb = self.model.get_image_features(pixel_values = inputs.pixel_values.half())
+        img_emb = F.normalize(img_emb, p = 2, dim = -1)
+
+        text_emb = self.model.get_text_features(input_ids = inputs.input_ids, attention_mask = inputs.attention_mask)
+        text_emb = F.normalize(text_emb, p = 2, dim = -1)
+
+        scores = self.model.logit_scale.exp() * (text_emb @ img_emb.T)
+        scores = scores.diag().sum().item()
+        return scores
+
+    @torch.no_grad()
+    def __call__(self, sampler, model):
+        pick_score_total = 0.
+
+        total_batches = self.n_samples // self.batch_size
+
+        print("Scoring...")
+        for i in tqdm(range(total_batches)):
+            prompt_batch = self.prompts[i*self.batch_size:(i+1)*self.batch_size]
+            
+            # Generate images and make them PIL
+            images = sampler.sample(self.batch_size, model, prompt_batch) #[-1,1] [b,c,h,w]
+            images = (images.clamp(-1,1)+1)/2
+            images = (images * 255).byte().cpu().permute(0,2,3,1).numpy()
+            pil_images = [Image.fromarray(img) for img in images]
+
+            
+            score = self.call_pickscore(prompt_batch, pil_images)
+            pick_score_total += score
+
+            # Free up CUDA memory
+            del images
+            torch.cuda.empty_cache()
+
+        return pick_score_total / self.n_samples
+
+if __name__ == "__main__":
+    class DummySampler:
+        def sample(self, n_samples, model, prompts):
+            noise = torch.randn(n_samples, 3, 512, 512)
+            return torch.clamp(noise, -1, 1)
+
+    # Create a dummy model (None in this case)
+    model = None
+
+    # Create the dummy sampler
+    sampler = DummySampler()
+
+    # Initialize PickScorer
+    scorer = PickScorer(batch_size=4, n_samples=16)  # Adjust batch_size and n_samples as needed
+
+    # Test PickScorer
+    score = scorer(sampler, model)
+    print(f"Total PickScore: {score}")
+        
+        

--- a/train.py
+++ b/train.py
@@ -27,4 +27,12 @@ if __name__ == "__main__":
         deterministic=True  # This will use a fixed seed internally
     )
 
-    trainer.train(model, train_loader)
+    val_loader = create_loader(
+        dataset_name=train_cfg.dataset,
+        batch_size=train_cfg.batch_size * train_cfg.val_batch_mult,
+        image_size=model_cfg.image_size,
+        deterministic=True,
+        split='validation'
+    ) if train_cfg.val_interval != -1 else None
+
+    trainer.train(model, train_loader, val_loader)


### PR DESCRIPTION
Normalized Transformer:
- https://arxiv.org/pdf/2410.01131
REPA:
- https://arxiv.org/pdf/2410.06940

Normalized transformers and REPA improve training so significantly that there is no need to preserve any of the old training code. 

Normalized Transformer Related Additions
- New spherical modulation layer to bridge gap between AdaLN_0 and normalized transformer assumptions

REPA
- nGPT higher LR hurts REPA, so normalize the MLP as well
- Normalize DinoV2 embeddings as well
- Cosine similarity between normalized embeddings gives much better signal than spatial MSE
- Added patch pooling to allow N=1024 RFT to interface with N=256 DINO

Validation
- Add coco validation split for val loss
- Add PickScore for image scoring

Results:
- Normalized transformer enables 10x higher learning rates with seemingly no performance impact
- 1e-3 seems a better default than 1e-4 now
- REPA causes loss to become much much smaller way way faster